### PR TITLE
feat: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -47,6 +47,17 @@ async def create_book(book: Book):
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+@router.get(
+    "/{book_id}", response_model=Book, status_code=status.HTTP_200_OK
+)
+async def get_book(book_id: int):
+    """Retrieve a book by its ID."""
+    book = db.get_book(book_id)
+    
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    
+    return book
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task](https://hng12.slack.com/archives/C088PK3KE2K/p1739195475622999)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbot` as a collaborator.  
- Deployment URL: `http://18.215.176.239/`